### PR TITLE
fix: remove the Sign button of Aggregate Bonded transaction

### DIFF
--- a/src/components/organisms/transaction/AggregateTransaction.js
+++ b/src/components/organisms/transaction/AggregateTransaction.js
@@ -108,19 +108,9 @@ class AggregateTransaction extends BaseTransactionItem<Props> {
                 <TableView
                     data={{
                         innerTxs: transaction.innerTransactions.length,
+                        signature: this.needsSignature() && 'You can use Symbol Desktop Wallet or Symbol CLI to review and sign this transaction.'
                     }}
                 />
-                {this.needsSignature() && (
-                    <Row justify="space-between">
-                        <Button
-                            style={{ padding: 0 }}
-                            isLoading={isLoading}
-                            text={translate('history.transaction.sign')}
-                            theme="light"
-                            onPress={() => this.sign()}
-                        />
-                    </Row>
-                )}
             </View>
         );
     };

--- a/src/components/organisms/transaction/AggregateTransaction.js
+++ b/src/components/organisms/transaction/AggregateTransaction.js
@@ -89,6 +89,11 @@ class AggregateTransaction extends BaseTransactionItem<Props> {
 
     renderDetails = () => {
         const { transaction, isLoading, isMultisig } = this.props;
+        const table = { innerTxs: transaction.innerTransactions.length };
+        if (this.needsSignature()) {
+            table.signature = 'You can use Symbol Desktop Wallet or Symbol CLI to review and sign this transaction.'; //TODO: remove when inner transactions presentation is ready
+        }
+
         if (this.isPostLaunchOptIn()) {
             const amount = this.postLaunchAmount();
             return (
@@ -105,12 +110,7 @@ class AggregateTransaction extends BaseTransactionItem<Props> {
         }
         return (
             <View>
-                <TableView
-                    data={{
-                        innerTxs: transaction.innerTransactions.length,
-                        signature: this.needsSignature() && 'You can use Symbol Desktop Wallet or Symbol CLI to review and sign this transaction.'
-                    }}
-                />
+                <TableView data={table}/>
             </View>
         );
     };

--- a/src/locales/translations/en.json
+++ b/src/locales/translations/en.json
@@ -394,6 +394,7 @@
 		}
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "Type",
 		"recipientAddress": "Recipient Address",
 		"messageText": "Message / Memo",

--- a/src/locales/translations/es.json
+++ b/src/locales/translations/es.json
@@ -399,6 +399,7 @@
 		"fast": "Rápida"
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "Tipo",
 		"recipientAddress": "Dirección de recepción",
 		"messageText": "Mensaje / Memo",

--- a/src/locales/translations/it.json
+++ b/src/locales/translations/it.json
@@ -394,6 +394,7 @@
 		}
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "Type",
 		"recipientAddress": "Indirizzo del destinatario",
 		"messageText": "Messaggio",

--- a/src/locales/translations/ja.json
+++ b/src/locales/translations/ja.json
@@ -394,6 +394,7 @@
 		}
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "タイプ",
 		"recipientAddress": "受け取りアドレス",
 		"messageText": "メッセージ/メモ",

--- a/src/locales/translations/ru.json
+++ b/src/locales/translations/ru.json
@@ -394,6 +394,7 @@
 		}
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "Тип",
 		"recipientAddress": "Адрес получателя",
 		"messageText": "Сообщение / Мемо",

--- a/src/locales/translations/zh.json
+++ b/src/locales/translations/zh.json
@@ -394,6 +394,7 @@
 		}
 	},
 	"table": {
+		"signature": "Signature",
 		"type": "类型",
 		"recipientAddress": "收件人地址",
 		"messageText": "消息/备忘录",


### PR DESCRIPTION
The button replaced with the message:
![image](https://user-images.githubusercontent.com/33131259/135657000-70648538-5715-45a5-9645-20f902ae6b42.png)
