### PR TITLE
Feature CI/CD upload artifacts to s3 bucket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,19 @@ pipeline {
             }
         }
 
+        stage('Upload Android') {
+            when {
+                expression {
+                    TARGET_OS == 'All' || TARGET_OS == 'Android'
+                }
+            }
+            steps {
+                // upload apk artifact to folder(env.branch_name) in AWS S3 bucket (s3://symbol-mobile-builds/branches) 
+                // note that there is a s3 bucket retention policy deleting the files older than 60 days
+                sh "aws s3 cp android/app/build/outputs/apk/prod/release/ s3://symbol-mobile-builds/branches/\$BRANCH_NAME --recursive --exclude '*' --include '*.apk'"
+            }
+        }
+
         // deploy to testnet
         stage ('Deploy IOS - Alpha version') {
             when {
@@ -98,7 +111,17 @@ pipeline {
                 }
             }
             steps {
-                sh 'cd ios && export APP_STORE_CONNECT_API_KEY_KEY_ID=${APP_STORE_CONNECT_API_KEY_KEY_ID} && export APP_STORE_CONNECT_API_KEY_ISSUER_ID=${APP_STORE_CONNECT_API_KEY_ISSUER_ID} && export APP_STORE_CONNECT_API_KEY_KEY=${APP_STORE_CONNECT_API_KEY_KEY} && export FASTLANE_KEYCHAIN=${FASTLANE_KEYCHAIN} && export FASTLANE_KEYCHAIN_PASSWORD=${FASTLANE_KEYCHAIN_PASSWORD} && export RUNNING_ON_CI=${RUNNING_ON_CI} && export BUILD_NUMBER=${BUILD_NUMBER} && export VERSION_NUMBER=${VERSION_NUMBER} && bundle exec fastlane beta'
+                sh '''
+                    cd ios && export APP_STORE_CONNECT_API_KEY_KEY_ID=${APP_STORE_CONNECT_API_KEY_KEY_ID} \
+                           && export APP_STORE_CONNECT_API_KEY_ISSUER_ID=${APP_STORE_CONNECT_API_KEY_ISSUER_ID} \
+                           && export APP_STORE_CONNECT_API_KEY_KEY=${APP_STORE_CONNECT_API_KEY_KEY} \
+                           && export FASTLANE_KEYCHAIN=${FASTLANE_KEYCHAIN} \
+                           && export FASTLANE_KEYCHAIN_PASSWORD=${FASTLANE_KEYCHAIN_PASSWORD} \
+                           && export RUNNING_ON_CI=${RUNNING_ON_CI} \
+                           && export BUILD_NUMBER=${BUILD_NUMBER} \
+                           && export VERSION_NUMBER=${VERSION_NUMBER} \
+                           && bundle exec fastlane beta
+                '''
                 sh "echo 'Deployed to TestFlight. Version:${VERSION_NUMBER}, Build:${BUILD_NUMBER}'"
             }
         }

--- a/android/tools/script-git-version.gradle
+++ b/android/tools/script-git-version.gradle
@@ -16,7 +16,7 @@ ext {
     gitVersionCode = git.log().size()
     gitVersionCodeTime = git.head().time
     buildDate = new Date()
-    customVersionName = "${gitShortVersionName}-${git.head().abbreviatedId}-${buildDate.format('yyMMdd')}"
+    customVersionName = "${gitShortVersionName}-${git.head().abbreviatedId}-${buildDate.format('yyMMddHHmm')}"
 }
 
 task printVersion() {


### PR DESCRIPTION
* Upload android artifacts to s3 bucket (s3://symbol-mobile-builds)
   * note that there is a s3 bucket retention policy deleting the files older than 60 days 
   * apk artifacts will be available at https://symbol-mobile-builds.s3.us-west-2.amazonaws.com/list.html
![image](https://user-images.githubusercontent.com/6256269/140831649-9e3eb75b-0bd5-4c0e-b434-2ec96f0957a7.png)

* IOS deployment script is reformatted