### PR TITLE
fix fee selector problems when recipient address is not provided

### DIFF
--- a/src/screens/Send.js
+++ b/src/screens/Send.js
@@ -59,15 +59,19 @@ class Send extends Component<Props, State> {
 		const { recipientAddress, amount, mosaicName, message } = this.props;
         let isMosaicPresent = true;
 
-		if(recipientAddress)
-			this.onAddressChange(recipientAddress);
-		if(mosaicName)
+        if (recipientAddress) {
+            this.onAddressChange(recipientAddress);
+        }
+        if (mosaicName) {
             isMosaicPresent = await this.onMosaicChange(mosaicName);
-		if(amount && isMosaicPresent)
-			this.onAmountChange(amount);
-		if(message)
-			this.onMessageChange(message);
-        await this.updateMaxFee()
+        }
+        if (amount && isMosaicPresent) {
+            this.onAmountChange(amount);
+        }
+        if (message) {
+            this.onMessageChange(message);
+        }
+        await this.updateMaxFee();
     };
 
     verify = () => {

--- a/src/screens/Send.js
+++ b/src/screens/Send.js
@@ -67,7 +67,7 @@ class Send extends Component<Props, State> {
 			this.onAmountChange(amount);
 		if(message)
 			this.onMessageChange(message);
-
+        await this.updateMaxFee()
     };
 
     verify = () => {

--- a/src/store/transfer.js
+++ b/src/store/transfer.js
@@ -58,9 +58,10 @@ export default {
         getMaxFee: async ({ state }, payload) => {
             const networkType = NetworkService.getNetworkTypeFromModel(state.network.selectedNetwork);
             const dummyAccount = Account.generateNewAccount(networkType);
+            const recipientAddress =  payload.recipientAddress || dummyAccount.address.plain();
             const transactionModel = {
                 type: 'transfer',
-                recipientAddress: payload.recipientAddress,
+                recipientAddress: recipientAddress,
                 messageText: payload.message,
                 messageEncrypted: payload.messageEncrypted,
                 mosaics: payload.mosaics,


### PR DESCRIPTION
fixes #254
**Current Issues:**
- Slow/Recommended/Fast fees have fixed values (not calculated). It should be calculated.
-  Switching fees using selector makes it stuck in spinning.

**Solution:**
- Used Dummy account to pre-calculate fees in case the user hasn't entered a valid one.