### PR TITLE
fix: handle selected node down when application start.

### DIFF
--- a/src/store/network.js
+++ b/src/store/network.js
@@ -83,6 +83,16 @@ export default {
             const networkType = getDefaultNetworkType();
             const nodeList = networkType === 'mainnet' ? state.network.mainnetNodes : state.network.testnetNodes;
 
+            // verify selected node availability
+            if (selectedNode) {
+                try {
+                    await NetworkService.getNetworkModelFromNode(selectedNode);
+                } catch (error) {
+                    // reset selected node
+                    selectedNode = null;
+                }
+            }
+
             // assign node, if node list available and selectedNode is not set
             if (nodeList.length && !selectedNode) {
                 const randomIndex = Math.floor(Math.random() * nodeList.length); //NOSONAR


### PR DESCRIPTION
The application crash was caused by the selected node being unreachable.

To resolve this, we will verify the selected node status, if the node is unreachable, it will be randomly assigned the new node from the node list.