### PR TITLE
sdk api 30 updates on build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,9 +3,9 @@
 buildscript {
     ext {
         minSdkVersion = 23
-        compileSdkVersion = 29
-        targetSdkVersion = 29
-        supportLibVersion = "28.0.0"
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+        supportLibVersion = "30.0.0"
         RNNKotlinVersion = "1.3.61" // Or any version above 1.3.x
         RNNKotlinStdlib = "kotlin-stdlib-jdk8"
     }


### PR DESCRIPTION
As @coiki reported, Symbol android mobile app was blocked on Google Play Store due to min Android version requirements(API 30). This PR fixes the Issue.
https://developer.android.com/about/versions/11/setup-sdk