### PR TITLE
feat: add the app version check and update message

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -212,6 +212,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.facebook.fresco:animated-gif:2.0.0'
+    implementation 'com.google.android.play:core:1.7.3'
+    implementation 'com.android.support:design:27.1.1'
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -206,6 +206,7 @@ android {
 }
 
 dependencies {
+    implementation project(':react-native-version-info')
     implementation project(':react-native-video')
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation fileTree(dir: "libs", include: ["*.jar"])

--- a/android/app/src/main/java/nem/group/wallet/InAppUpdateModule.java
+++ b/android/app/src/main/java/nem/group/wallet/InAppUpdateModule.java
@@ -1,0 +1,161 @@
+package nem.group.symbol.wallet;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.graphics.Color;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.google.android.material.snackbar.Snackbar;
+import com.google.android.play.core.appupdate.AppUpdateInfo;
+import com.google.android.play.core.appupdate.AppUpdateManager;
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
+import com.google.android.play.core.install.InstallState;
+import com.google.android.play.core.install.InstallStateUpdatedListener;
+import com.google.android.play.core.install.model.AppUpdateType;
+import com.google.android.play.core.install.model.InstallStatus;
+import com.google.android.play.core.install.model.UpdateAvailability;
+import com.google.android.play.core.tasks.Task;
+
+import java.util.Objects;
+
+import static android.app.Activity.RESULT_OK;
+
+public class InAppUpdateModule extends ReactContextBaseJavaModule 
+implements InstallStateUpdatedListener, LifecycleEventListener {
+    private AppUpdateManager appUpdateManager;
+    private static ReactApplicationContext reactContext;
+    private static final int STALE_DAYS = 5;
+    private static final int MY_REQUEST_CODE = 0;
+
+    private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
+        @Override
+        public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
+            if (requestCode == MY_REQUEST_CODE) {
+                if (resultCode != RESULT_OK) {
+                    System.out.println("Update flow failed! Result code: " + resultCode);
+                    // If the update is cancelled or fails,
+                    // you can request to start the update again.
+                }
+            }
+        }
+    };
+
+    InAppUpdateModule(ReactApplicationContext context) {
+        super(context);
+        reactContext = context;
+        reactContext.addActivityEventListener(mActivityEventListener);
+        reactContext.addLifecycleEventListener(this);
+
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return "InAppUpdate";
+    }
+
+    @ReactMethod
+    public void checkUpdate() {
+        appUpdateManager = AppUpdateManagerFactory.create(reactContext);
+        appUpdateManager.registerListener(this);
+        Task<AppUpdateInfo> appUpdateInfoTask = appUpdateManager.getAppUpdateInfo();
+        appUpdateInfoTask.addOnSuccessListener(appUpdateInfo -> {
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+                    && appUpdateInfo.clientVersionStalenessDays() != null
+                    && appUpdateInfo.clientVersionStalenessDays() > STALE_DAYS
+                    && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
+                try {
+                    appUpdateManager.startUpdateFlowForResult(
+                            appUpdateInfo,
+                            AppUpdateType.IMMEDIATE,
+                            reactContext.getCurrentActivity(),
+                            MY_REQUEST_CODE);
+                } catch (IntentSender.SendIntentException e) {
+                    e.printStackTrace();
+                }
+            }else{
+                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
+                        && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
+                    try {
+                        appUpdateManager.startUpdateFlowForResult(
+                                appUpdateInfo,
+                                AppUpdateType.FLEXIBLE,
+                                reactContext.getCurrentActivity(),
+                                MY_REQUEST_CODE);
+                    } catch (IntentSender.SendIntentException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+        });
+
+    }
+
+    @Override
+    public void onStateUpdate(InstallState state) {
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            popupSnackbarForCompleteUpdate();
+        }
+    }
+
+  private void popupSnackbarForCompleteUpdate() {
+        Snackbar snackbar =
+                Snackbar.make(Objects.requireNonNull(reactContext
+                .getCurrentActivity())
+                .findViewById(android.R.id.content).
+                getRootView(),
+                        "An update has just been downloaded.",
+                        Snackbar.LENGTH_INDEFINITE);
+        snackbar.setAction("RESTART", view -> appUpdateManager.completeUpdate());
+        snackbar.setActionTextColor(Color.GREEN);
+        snackbar.show();
+    }
+
+    @Override
+    public void onHostResume() {
+        if (appUpdateManager != null) {
+            appUpdateManager
+                    .getAppUpdateInfo()
+                    .addOnSuccessListener(
+                            appUpdateInfo -> {
+                                if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
+                                    popupSnackbarForCompleteUpdate();
+                                }
+                                if (appUpdateInfo.updateAvailability()
+                                        == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                                    try {
+                                        appUpdateManager.startUpdateFlowForResult(
+                                                appUpdateInfo,
+                                                AppUpdateType.IMMEDIATE,
+                                                reactContext.getCurrentActivity(),
+                                                MY_REQUEST_CODE);
+                                    } catch (IntentSender.SendIntentException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+
+                            });
+        }
+    }
+
+    @Override
+    public void onHostPause() {
+
+    }
+
+    @Override
+    public void onHostDestroy() {
+        if (appUpdateManager != null) {
+            appUpdateManager.unregisterListener(this);
+        }
+    }
+}

--- a/android/app/src/main/java/nem/group/wallet/InAppUpdateModule.java
+++ b/android/app/src/main/java/nem/group/wallet/InAppUpdateModule.java
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.google.android.material.snackbar.Snackbar;
 import com.google.android.play.core.appupdate.AppUpdateInfo;
 import com.google.android.play.core.appupdate.AppUpdateManager;
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
@@ -32,17 +31,14 @@ public class InAppUpdateModule extends ReactContextBaseJavaModule
 implements InstallStateUpdatedListener, LifecycleEventListener {
     private AppUpdateManager appUpdateManager;
     private static ReactApplicationContext reactContext;
-    private static final int STALE_DAYS = 5;
-    private static final int MY_REQUEST_CODE = 0;
+    private static final int REQUEST_CODE = 0;
 
     private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
-            if (requestCode == MY_REQUEST_CODE) {
+            if (requestCode == REQUEST_CODE) {
                 if (resultCode != RESULT_OK) {
                     System.out.println("Update flow failed! Result code: " + resultCode);
-                    // If the update is cancelled or fails,
-                    // you can request to start the update again.
                 }
             }
         }
@@ -53,7 +49,6 @@ implements InstallStateUpdatedListener, LifecycleEventListener {
         reactContext = context;
         reactContext.addActivityEventListener(mActivityEventListener);
         reactContext.addLifecycleEventListener(this);
-
     }
 
     @NonNull
@@ -68,82 +63,50 @@ implements InstallStateUpdatedListener, LifecycleEventListener {
         appUpdateManager.registerListener(this);
         Task<AppUpdateInfo> appUpdateInfoTask = appUpdateManager.getAppUpdateInfo();
         appUpdateInfoTask.addOnSuccessListener(appUpdateInfo -> {
-            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-                    && appUpdateInfo.clientVersionStalenessDays() != null
-                    && appUpdateInfo.clientVersionStalenessDays() > STALE_DAYS
-                    && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
+            if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE) {
                 try {
                     appUpdateManager.startUpdateFlowForResult(
-                            appUpdateInfo,
-                            AppUpdateType.IMMEDIATE,
-                            reactContext.getCurrentActivity(),
-                            MY_REQUEST_CODE);
+                        appUpdateInfo,
+                        AppUpdateType.FLEXIBLE,
+                        reactContext.getCurrentActivity(),
+                        REQUEST_CODE
+                    );
                 } catch (IntentSender.SendIntentException e) {
                     e.printStackTrace();
                 }
-            }else{
-                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-                        && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
-                    try {
-                        appUpdateManager.startUpdateFlowForResult(
-                                appUpdateInfo,
-                                AppUpdateType.FLEXIBLE,
-                                reactContext.getCurrentActivity(),
-                                MY_REQUEST_CODE);
-                    } catch (IntentSender.SendIntentException e) {
-                        e.printStackTrace();
-                    }
-                }
             }
-
         });
-
     }
 
     @Override
     public void onStateUpdate(InstallState state) {
         if (state.installStatus() == InstallStatus.DOWNLOADED) {
-            popupSnackbarForCompleteUpdate();
+            appUpdateManager.completeUpdate();
         }
-    }
-
-  private void popupSnackbarForCompleteUpdate() {
-        Snackbar snackbar =
-                Snackbar.make(Objects.requireNonNull(reactContext
-                .getCurrentActivity())
-                .findViewById(android.R.id.content).
-                getRootView(),
-                        "An update has just been downloaded.",
-                        Snackbar.LENGTH_INDEFINITE);
-        snackbar.setAction("RESTART", view -> appUpdateManager.completeUpdate());
-        snackbar.setActionTextColor(Color.GREEN);
-        snackbar.show();
     }
 
     @Override
     public void onHostResume() {
         if (appUpdateManager != null) {
             appUpdateManager
-                    .getAppUpdateInfo()
-                    .addOnSuccessListener(
-                            appUpdateInfo -> {
-                                if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
-                                    popupSnackbarForCompleteUpdate();
-                                }
-                                if (appUpdateInfo.updateAvailability()
-                                        == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-                                    try {
-                                        appUpdateManager.startUpdateFlowForResult(
-                                                appUpdateInfo,
-                                                AppUpdateType.IMMEDIATE,
-                                                reactContext.getCurrentActivity(),
-                                                MY_REQUEST_CODE);
-                                    } catch (IntentSender.SendIntentException e) {
-                                        e.printStackTrace();
-                                    }
-                                }
-
-                            });
+                .getAppUpdateInfo()
+                .addOnSuccessListener(appUpdateInfo -> {
+                    if (appUpdateInfo.installStatus() == InstallStatus.DOWNLOADED) {
+                        appUpdateManager.completeUpdate();
+                    }
+                    if (appUpdateInfo.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
+                        try {
+                            appUpdateManager.startUpdateFlowForResult(
+                                appUpdateInfo,
+                                AppUpdateType.FLEXIBLE,
+                                reactContext.getCurrentActivity(),
+                                REQUEST_CODE
+                            );
+                        } catch (IntentSender.SendIntentException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                });
         }
     }
 

--- a/android/app/src/main/java/nem/group/wallet/InAppUpdatePackage.java
+++ b/android/app/src/main/java/nem/group/wallet/InAppUpdatePackage.java
@@ -1,0 +1,30 @@
+
+package nem.group.symbol.wallet;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class InAppUpdatePackage implements ReactPackage {
+    @NonNull
+    @Override
+    public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
+
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new InAppUpdateModule(reactContext));
+        return modules;
+    }
+
+    @NonNull
+    @Override
+    public List<ViewManager> createViewManagers(@NonNull ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/android/app/src/main/java/nem/group/wallet/MainApplication.java
+++ b/android/app/src/main/java/nem/group/wallet/MainApplication.java
@@ -26,6 +26,7 @@ public class MainApplication extends NavigationApplication {
     protected List<ReactPackage> getPackages() {
       @SuppressWarnings("UnnecessaryLocalVariable")
       List<ReactPackage> packages = new PackageList(this).getPackages();
+      packages.add(new InAppUpdatePackage());
       // Packages that cannot be autolinked yet can be added manually here, for
       // example:
       // packages.add(new MyReactNativePackage());

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'NEMCatapultWallet'
+include ':react-native-version-info'
+project(':react-native-version-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-version-info/android')
 include ':react-native-video'
 project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,4 +39,6 @@ target 'SymbolWallet' do
   use_native_modules!
   pod 'react-native-video', :path => '../node_modules/react-native-video'
 
+  pod 'react-native-version-info', :path => '../node_modules/react-native-version-info'
+
 end

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-native-touch-id": "^4.4.1",
     "react-native-udp": "^2.1.0",
     "react-native-url": "^0.0.2",
+    "react-native-version-info": "^1.1.1",
     "react-native-video": "^5.1.0-alpha8",
     "react-native-view-shot": "^3.0.2",
     "react-redux": "^7.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -70,12 +70,6 @@ export const startApp = async () => {
         await launchWallet();
         SplashScreen.hide();
     }
-
-    VersionService.checkAppNeedsUpdate().then(
-        appNeedsUpdate =>
-            appNeedsUpdate === true &&
-            Alert.alert(translate('unsortedKeys.alertNewVersionAppStoreTitle'), translate('unsortedKeys.alertNewVersionAppStoreBody'))
-    );
 };
 
 const launchWallet = async () => {
@@ -89,12 +83,22 @@ const launchWallet = async () => {
         if (isPin)
             Router.showPasscode({
                 resetPasscode: false,
-                onSuccess: () => Router.goToDashboard(),
+                onSuccess: () => launchScreenAndCheckUpdate(Router.goToDashboard),
             });
-        else Router.goToDashboard();
+        else launchScreenAndCheckUpdate(Router.goToDashboard);
     } else {
-        Router.goToTermsAndPrivacy({});
+        launchScreenAndCheckUpdate(Router.goToTermsAndPrivacy);
     }
+};
+
+const launchScreenAndCheckUpdate = routerCallback => {
+    routerCallback();
+
+    VersionService.checkAppNeedsUpdate().then(
+        appNeedsUpdate =>
+            appNeedsUpdate === true &&
+            Alert.alert(translate('unsortedKeys.alertNewVersionAppStoreTitle'), translate('unsortedKeys.alertNewVersionAppStoreBody'))
+    );
 };
 
 const scheduleBackgroundJob = () => {

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import SplashScreen from 'react-native-splash-screen';
 import { hasUserSetPinCode } from '@haskkor/react-native-pincode';
 import * as Config from './config/environment';
 import { VersionService } from '@src/services/VersionService';
-import { setI18nConfig } from './locales/i18n';
+import translate, { setI18nConfig } from './locales/i18n';
 import { Router } from './Router';
 import { AsyncCache } from './utils/storage/AsyncCache';
 import store from '@src/store';
@@ -74,10 +74,7 @@ export const startApp = async () => {
     VersionService.checkAppNeedsUpdate().then(
         appNeedsUpdate =>
             appNeedsUpdate === true &&
-            Alert.alert(
-                'New version of Symbol Wallet is available on App Store',
-                'We strongly recommend that you update to the latest version!'
-            )
+            Alert.alert(translate('unsortedKeys.alertNewVersionAppStoreTitle'), translate('unsortedKeys.alertNewVersionAppStoreBody'))
     );
 };
 

--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@
  * @flow
  */
 import React from 'react';
-import { Text, TextInput } from 'react-native';
+import { NativeModules, Platform, Text, TextInput } from 'react-native';
 
 import SplashScreen from 'react-native-splash-screen';
 import { hasUserSetPinCode } from '@haskkor/react-native-pincode';
@@ -58,6 +58,10 @@ export const startApp = async () => {
 
     const selectedLanguage = await AsyncCache.getSelectedLanguage();
     setI18nConfig(selectedLanguage);
+
+    if (Platform.OS === 'android') {
+        NativeModules.InAppUpdate.checkUpdate();
+    }
 
     if (dataSchemaVersion !== CURRENT_DATA_SCHEMA) {
         SplashScreen.hide();

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,12 @@
  * @flow
  */
 import React from 'react';
-import { NativeModules, Platform, Text, TextInput } from 'react-native';
+import { Alert, Text, TextInput } from 'react-native';
 
 import SplashScreen from 'react-native-splash-screen';
 import { hasUserSetPinCode } from '@haskkor/react-native-pincode';
 import * as Config from './config/environment';
+import { VersionService } from '@src/services/VersionService';
 import { setI18nConfig } from './locales/i18n';
 import { Router } from './Router';
 import { AsyncCache } from './utils/storage/AsyncCache';
@@ -70,9 +71,14 @@ export const startApp = async () => {
         SplashScreen.hide();
     }
 
-    if (Platform.OS === 'android') {
-        NativeModules.InAppUpdate.checkUpdate();
-    }
+    VersionService.checkAppNeedsUpdate().then(
+        appNeedsUpdate =>
+            appNeedsUpdate === true &&
+            Alert.alert(
+                'New version of Symbol Wallet is available on App Store',
+                'We strongly recommend that you update to the latest version!'
+            )
+    );
 };
 
 const launchWallet = async () => {

--- a/src/App.js
+++ b/src/App.js
@@ -59,10 +59,6 @@ export const startApp = async () => {
     const selectedLanguage = await AsyncCache.getSelectedLanguage();
     setI18nConfig(selectedLanguage);
 
-    if (Platform.OS === 'android') {
-        NativeModules.InAppUpdate.checkUpdate();
-    }
-
     if (dataSchemaVersion !== CURRENT_DATA_SCHEMA) {
         SplashScreen.hide();
         Router.goToWalletLoading({
@@ -72,6 +68,10 @@ export const startApp = async () => {
     } else {
         await launchWallet();
         SplashScreen.hide();
+    }
+
+    if (Platform.OS === 'android') {
+        NativeModules.InAppUpdate.checkUpdate();
     }
 };
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -135,7 +135,7 @@ export class Router {
             };
         }
 
-        this.screens.forEach(([key, ScreenComponent]) =>
+        Router.screens.forEach(([key, ScreenComponent]) =>
             Navigation.registerComponent(key, () => WrappedComponentWithStore(gestureHandlerRootHOC(ScreenComponent)))
         );
 
@@ -143,58 +143,58 @@ export class Router {
     }
 
     static goToTermsAndPrivacy(passProps, parentComponent?) {
-        return this.goToScreen(TERMS_AND_PRIVACY_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(TERMS_AND_PRIVACY_SCREEN, passProps, parentComponent);
     }
     static goToCreateOrImport(passProps, parentComponent?) {
-        return this.goToScreen(CREATE_OR_IMPORT_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(CREATE_OR_IMPORT_SCREEN, passProps, parentComponent);
     }
     static goToWalletName(passProps, parentComponent?) {
-        return this.goToScreen(WALLET_NAME_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(WALLET_NAME_SCREEN, passProps, parentComponent);
     }
     static goToGenerateBackup(passProps, parentComponent?) {
-        return this.goToScreen(GENERATE_BACKUP_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(GENERATE_BACKUP_SCREEN, passProps, parentComponent);
     }
     static goToShowQRCode(passProps, parentComponent?) {
-        return this.goToScreen(SHOW_QR_CODE_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SHOW_QR_CODE_SCREEN, passProps, parentComponent);
     }
     static goToDashboard(passProps, parentComponent?) {
-        return this.goToScreen(DASHBOARD_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(DASHBOARD_SCREEN, passProps, parentComponent);
     }
     static goToVerifyMnemonics(passProps, parentComponent?) {
-        return this.goToScreen(VERIFY_MNEMONICS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(VERIFY_MNEMONICS_SCREEN, passProps, parentComponent);
     }
     static goToShowMnemonics(passProps, parentComponent?) {
-        return this.goToScreen(SHOW_MNEMONICS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SHOW_MNEMONICS_SCREEN, passProps, parentComponent);
     }
     static goToImportOptions(passProps, parentComponent?) {
-        return this.goToScreen(IMPORT_OPTION_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(IMPORT_OPTION_SCREEN, passProps, parentComponent);
     }
     static goToScanQRCode(passProps, parentComponent?) {
-        return this.goToScreen(SCAN_QR_CODE_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SCAN_QR_CODE_SCREEN, passProps, parentComponent);
     }
     static goToEnterMnemonics(passProps, parentComponent?) {
-        return this.goToScreen(ENTER_MNEMONICS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(ENTER_MNEMONICS_SCREEN, passProps, parentComponent);
     }
     static goToWalletLoading(passProps, parentComponent?) {
-        return this.goToScreen(WALLET_LOADING_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(WALLET_LOADING_SCREEN, passProps, parentComponent);
     }
     static goToConfirmTransaction(passProps, parentComponent?) {
-        return this.goToScreen(CONFIRM_TRANSACTION_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(CONFIRM_TRANSACTION_SCREEN, passProps, parentComponent);
     }
     static goToSettings(passProps, parentComponent?) {
-        return this.goToScreen(SETTINGS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SETTINGS_SCREEN, passProps, parentComponent);
     }
     static showPasscode(passProps, parentComponent?) {
-        return this.goToScreen(PASSCODE_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(PASSCODE_SCREEN, passProps, parentComponent);
     }
     static goToHarvest(passProps, parentComponent?) {
-        return this.goToScreen(HARVEST_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(HARVEST_SCREEN, passProps, parentComponent);
     }
     static goToAccountDetails(passProps, parentComponent?) {
-        return this.goToScreen(ACCOUNT_DETAILS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(ACCOUNT_DETAILS_SCREEN, passProps, parentComponent);
     }
     static goToCreateAccount(passProps, parentComponent?) {
-        return this.goToScreen(CREATE_ACCOUNT_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(CREATE_ACCOUNT_SCREEN, passProps, parentComponent);
     }
     static scanQRCode(onRead, onClose) {
         const onCloseCallback = typeof onClose === 'function' ? onClose : () => {};
@@ -204,37 +204,37 @@ export class Router {
         });
     }
     static goToAddressBook(passProps, parentComponent?) {
-        return this.goToScreen(ADDRESS_BOOK_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(ADDRESS_BOOK_SCREEN, passProps, parentComponent);
     }
     static goToAddContact(passProps, parentComponent?) {
-        return this.goToScreen(ADD_CONTACT_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(ADD_CONTACT_SCREEN, passProps, parentComponent);
     }
     static goToContactProfile(passProps, parentComponent?) {
-        return this.goToScreen(CONTACT_PROFILE_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(CONTACT_PROFILE_SCREEN, passProps, parentComponent);
     }
     static goToSend(passProps, parentComponent?) {
-        return this.goToScreen(SEND_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SEND_SCREEN, passProps, parentComponent);
     }
     static goToShowLinkedKeys(passProps, parentComponent?) {
-        return this.goToScreen(SHOW_LINKED_KEYS_SCREEN, passProps, parentComponent);
+        return Router.goToScreen(SHOW_LINKED_KEYS_SCREEN, passProps, parentComponent);
     }
     static goToOptInWelcome(passProps, parentComponent?) {
-        return this.goToScreen(OPTIN_WELCOME, passProps, parentComponent);
+        return Router.goToScreen(OPTIN_WELCOME, passProps, parentComponent);
     }
     static goToOptInAccountDetails(passProps, parentComponent?) {
-        return this.goToScreen(OPTIN_ACCOUNT_DETAIL, passProps, parentComponent);
+        return Router.goToScreen(OPTIN_ACCOUNT_DETAIL, passProps, parentComponent);
     }
     static goToOptInSelectSymbolAccount(passProps, parentComponent?) {
-        return this.goToScreen(OPTIN_SYMBOL_ACCOUNT, passProps, parentComponent);
+        return Router.goToScreen(OPTIN_SYMBOL_ACCOUNT, passProps, parentComponent);
     }
     static goToOptInFinish(passProps, parentComponent?) {
-        return this.goToScreen(OPTIN_FINISH, passProps, parentComponent);
+        return Router.goToScreen(OPTIN_FINISH, passProps, parentComponent);
     }
     static goToNIS1AccountDetails(passProps, parentComponent?) {
-        return this.goToScreen(NIS1_ACCOUNT_DETAILS, passProps, parentComponent);
+        return Router.goToScreen(NIS1_ACCOUNT_DETAILS, passProps, parentComponent);
     }
     static goToOptinSelectSymbolMultisigDestination(passProps, parentComponent?) {
-        return this.goToScreen(OPTIN_SELECT_MULTISIG_DESTINATION, passProps, parentComponent);
+        return Router.goToScreen(OPTIN_SELECT_MULTISIG_DESTINATION, passProps, parentComponent);
     }
 
     static goToScreen(screen: string, passProps, parentComponent?) {

--- a/src/locales/translations/en.json
+++ b/src/locales/translations/en.json
@@ -744,7 +744,9 @@
 		"noPublicKeyWarning": "Can't encrypt message: Address doesn't have a public key",
 		"nothingToShow": "Nothing to show",
 		"currentAccount": "You",
-		"currentAddress": "Your address"
+		"currentAddress": "Your address",
+		"alertNewVersionAppStoreTitle": "The new version of Symbol Wallet is available in the App Store",
+		"alertNewVersionAppStoreBody": "We strongly recommend that you update to the latest version!"
 	},
 	"optin": {
 		"title": "Post-launch opt-in",

--- a/src/locales/translations/es.json
+++ b/src/locales/translations/es.json
@@ -721,7 +721,9 @@
 		"announce_success": "Transacción anunciada con exito",
 		"nothingToShow": "Nothing to show",
 		"currentAccount": "Tú",
-		"currentAddress": "Tu dirección"
+		"currentAddress": "Tu dirección",
+		"alertNewVersionAppStoreTitle": "The new version of Symbol Wallet is available in the App Store",
+		"alertNewVersionAppStoreBody": "We strongly recommend that you update to the latest version!"
 	},
 	"addressBook": {
 		"addressTakenWarning": "Esta dirección corresponde a otro contacto"

--- a/src/locales/translations/it.json
+++ b/src/locales/translations/it.json
@@ -717,7 +717,9 @@
 		"announce_success": "Transaction announced successfully",
 		"nothingToShow": "Nothing to show",
 		"currentAccount": "Tu",
-		"currentAddress": "Il tuo indirizzo"
+		"currentAddress": "Il tuo indirizzo",
+		"alertNewVersionAppStoreTitle": "La nuova versione di Symbol Wallet è disponibile nell'App Store",
+		"alertNewVersionAppStoreBody": "Consigliamo vivamente di eseguire l'aggiornamento all'ultima versione!"
 	},
 	"addressBook": {
 		"addressTakenWarning": "Questo indirizzo appartiene a un altro contatto"

--- a/src/locales/translations/ja.json
+++ b/src/locales/translations/ja.json
@@ -734,6 +734,8 @@
 		"announce_success": "トランザクションは正常に告知されました。",
 		"nothingToShow": "Nothing to show",
 		"currentAccount": "あなた",
-		"currentAddress": "あなたのアドレス"
+		"currentAddress": "あなたのアドレス",
+		"alertNewVersionAppStoreTitle": "新しいバージョンのSymbolウォレットがアプリストアから利用可能です。",
+		"alertNewVersionAppStoreBody": "最新のバージョンにアップデートする事を強く推奨します。"
 	}
 }

--- a/src/locales/translations/ru.json
+++ b/src/locales/translations/ru.json
@@ -743,7 +743,9 @@
 		"noPublicKeyWarning": "Не удается зашифровать сообщение: адрес не имеет публичного ключа",
 		"nothingToShow": "Пусто",
 		"currentAccount": "Вы",
-		"currentAddress": "Ваш адрес"
+		"currentAddress": "Ваш адрес",
+		"alertNewVersionAppStoreTitle": "В App Store доступна новая версия мобильного кошелька Symbol",
+		"alertNewVersionAppStoreBody": "Мы настоятельно рекомендуем Вам обновиться до последней версии!"
 	},
 	"optin": {
 		"title": "Пост Лаунч Опт-Ин",

--- a/src/locales/translations/zh.json
+++ b/src/locales/translations/zh.json
@@ -717,7 +717,9 @@
 		"announce_success": "交易成功宣布",
 		"nothingToShow": "Nothing to show",
 		"currentAccount": "你",
-		"currentAddress": "你的地址"
+		"currentAddress": "你的地址",
+		"alertNewVersionAppStoreTitle": "The new version of Symbol Wallet is available in the App Store",
+		"alertNewVersionAppStoreBody": "We strongly recommend that you update to the latest version!"
 	},
 	"addressBook": {
 		"addressTakenWarning": "地址属于另一个联系人"

--- a/src/services/VersionService.js
+++ b/src/services/VersionService.js
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native';
+
+const PRODUCT_BUNDLE_IDENTIFIER = 'com.nemgrouplimited.symbolwallet';
+
+export class VersionService {
+    static async checkAppVersionIsUpToDate(): Promise<boolean> {
+        if (Platform.OS === 'ios') {
+            const countryCode = 'us';
+            const endpoint = `https://itunes.apple.com/${countryCode}/lookup?bundleId=${PRODUCT_BUNDLE_IDENTIFIER}`;
+            const version = fetch(endpoint)
+                .then(response => response.json())
+                .then(json => json.results[0].version);
+
+            return version !== '0.0'; // TDOD: add compare to the current app version
+        }
+
+        return true;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10058,6 +10058,11 @@ react-native-vector-icons@^6.6.0:
     prop-types "^15.7.2"
     yargs "^15.0.2"
 
+react-native-version-info@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-version-info/-/react-native-version-info-1.1.1.tgz#1a79a48909c13c2ecc8314d54e477da00308abf5"
+  integrity sha512-huOj2WeEtmBbGa4+5ZiaKfi1ASN73Fbz81leYDWHhFKjsRdIis3vVgSJXXhHlC5wazsu1viujnLkGXVtu4Ns9g==
+
 react-native-video@^5.1.0-alpha8:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-native-video/-/react-native-video-5.1.1.tgz#89a7989efeb8d404611c06154d1da227a745d7d8"


### PR DESCRIPTION
**New functionality request**
The wallet should notify the user when a new version is available in the App / Play Store. 

**What's the change**
Android:
- Added [In-App Update](https://developer.android.com/guide/playcore/in-app-updates) native module.

![image](https://user-images.githubusercontent.com/33131259/150586688-3d2331b5-7aef-4af6-8dfd-bb1b9073bd63.png)

iOS:
- Added the method to fetch the latest app version from iTunes API.
- Compare this version with the current (installed) app version `CFBundleShortVersionString`.

![image](https://user-images.githubusercontent.com/33131259/150586584-83264e25-416a-4279-b641-49ca26ebf21b.png)
