### PR TITLE
task: remove status field from transaction graphic

### DIFF
--- a/src/components/transaction-graphic/TransactionGraphic.js
+++ b/src/components/transaction-graphic/TransactionGraphic.js
@@ -73,6 +73,7 @@ export default function TransactionGraphic(props: Props) {
         'deadline',
         'messageEncrypted',
         'hash',
+        'status',
     ]);
 
     const toggle = () => {


### PR DESCRIPTION
**What the current behaviour is.**
`Status` field is displayed for the aggregate inner transactions in the Transaction Graphic view.

**Why this is an issue.**
`Status` filed should not be displayed for inner transactions.

**What's the fix.**
Field is omitted.