### PR TITLE
hotfix: non sdk errors google play console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Fixed
 - Corrupted Paper Wallet Backup. [#284](https://github.com/symbol/mobile-wallet/issues/284)
 - Backup saving error. [#145](https://github.com/symbol/mobile-wallet/issues/145)
+- `okhttp` dependency is upgraded to fix Non-SDK errors reported by Google Play Console
+
 ### Changed
 - Removed dashes from addresses. [#296](https://github.com/symbol/mobile-wallet/issues/296)
 - Upgraded the dependency `symbol-sdk` version to `v1.0.3`.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -212,6 +212,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.facebook.fresco:animated-gif:2.0.0'
+    implementation("com.squareup.okhttp3:okhttp:3.12.13")
+    implementation("com.squareup.okhttp3:okhttp-urlconnection:3.12.13")
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
### What was the issue?
Google Play Console was reporting errors and advising fix those prior to release.
![image](https://user-images.githubusercontent.com/6256269/152428728-8676d473-6f73-488b-94cf-43b761a9f5b6.png)

### The fix
Upgraded the dependencies(`okhttp`) causing the errors.